### PR TITLE
fix support

### DIFF
--- a/joch/s3backup.xml
+++ b/joch/s3backup.xml
@@ -16,7 +16,7 @@
   <Overview>
     A simple way to backup important files to Amazon S3 and Glacier.
   </Overview>
-  <Support>-</Support>
+  <Support></Support>
   <Registry>https://registry.hub.docker.com/u/joch/s3backup/</Registry>
   <GitHub>https://github.com/joch/docker-s3backup</GitHub>
   <Repository>joch/s3backup</Repository>


### PR DESCRIPTION
Welcome to the party!

On a repo as a whole, I can apply a general support thread (if you create one)  But if you choose to create a general repo thread instead of one per container, then that "-" will mess it up.  And, IIRC having an empty entry there will also suppress the <Support> link (since there is no support thread per container or per repo at this moment.

Andrew
